### PR TITLE
Bug Fix: 443 Bytes `adapter_model.bin` files

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -708,12 +708,6 @@ def train():
     for k, v in dtypes.items():
         print(k, v, v/total)
 
-    if args.bits < 16:
-        old_state_dict = model.state_dict
-        model.state_dict = (
-            lambda self, *_, **__: get_peft_model_state_dict(self, old_state_dict())
-        ).__get__(model, type(model))
-
     all_metrics = {"run_name": args.run_name}
     # Training
     if args.do_train:


### PR DESCRIPTION
Aims to fix #38 and #41 

Currently, we get extremely small adapter files on checkpoint. 

This seems to be due to some issue in the PEFT library.

One of the working solution is to return to an older version which is not possible (since it doesn't contain QLoRA changes)

The following solution works on my setup with 4080 card as well as on Colab notebook.

It has been borrowed from [alpaca-lora](https://github.com/tloen/alpaca-lora/pull/359/files)
