### PR TITLE
Suppress pad_token warning message

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -603,7 +603,7 @@ def train():
         padding_side="right",
         use_fast=True,
     )
-    if tokenizer.pad_token is None:
+    if tokenizer._pad_token is None:
         smart_tokenizer_and_embedding_resize(
             special_tokens_dict=dict(pad_token=DEFAULT_PAD_TOKEN),
             tokenizer=tokenizer,


### PR DESCRIPTION
The use of `tokenizer.pad_token` when it is not set results in the warning `Using pad_token, but it is not set yet.` As we are about to set `pad_token`, this warning can be misleading. This PR changes the check to see if `pad_token` is set to use `tokenizer._pad_token` instead, which stops the warning from showing up

Fixes #62 