### PR TITLE
add support local training data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,9 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+
+# Training data folder
+data/training/*
+
+# VSCode Debug
+.vscode

--- a/README.md
+++ b/README.md
@@ -51,6 +51,19 @@ For models larger than 13B, we recommend adjusting the learning rate:
 python qlora.py –learning_rate 0.0001 --model_name_or_path <path_or_name>
 ```
 
+### Using Local Datasets
+
+You can specify the path to your dataset using the `--dataset` argument. If the `--dataset_format` argument is not set, it will default to the Alpaca format. Here are a few examples:
+
+- Training with an *alpaca* format dataset:
+  ```bash
+  python qlora.py --dataset="path/to/your/dataset"
+  ```
+- Training with a *self-instruct* format dataset:
+   ```bash
+   python qlora.py --dataset="path/to/your/dataset" --dataset_format="self-instruct"
+   ```
+
 ## Quantization
 Quantization parameters are controlled from the `BitsandbytesConfig` ([see HF documenation](https://huggingface.co/docs/transformers/main_classes/quantization#transformers.BitsAndBytesConfig)) as follows:
 - Loading in 4 bits is activated through `load_in_4bit`

--- a/qlora.py
+++ b/qlora.py
@@ -469,6 +469,8 @@ def extract_alpaca_dataset(example):
 def local_dataset(dataset_name):
     if dataset_name.endswith('.json'):
         full_dataset = Dataset.from_json(path_or_paths=dataset_name)
+    elif dataset_name.endswith('.jsonl'):
+        full_dataset = Dataset.from_json(filename=dataset_name, format='jsonlines')
     elif dataset_name.endswith('.csv'):
         full_dataset = Dataset.from_pandas(pd.read_csv(dataset_name))
     elif dataset_name.endswith('.tsv'):


### PR DESCRIPTION
This allows for using local datasets for training and the **dataset_format** defaults to `alpaca` format if one isn't set.

Also added `data/training/*` to .gitignore to allow a spot for training data