### PR TITLE
Set `train_on_source` to `True` by default

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -100,7 +100,7 @@ class TrainingArguments(transformers.Seq2SeqTrainingArguments):
         default=None
     )
     train_on_source: Optional[bool] = field(
-        default=False,
+        default=True,
         metadata={"help": "Whether to train on the input in addition to the target text."}
     )
     mmlu_split: Optional[str] = field(


### PR DESCRIPTION
Seems like the script doesn't train on the `input` field by default. This should change that.
I'm not sure why this was set to `False` in the first place.