### PR TITLE
Implement layer selection options for applying LoRA to during training

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -7,6 +7,7 @@ import json
 import os
 from os.path import exists, join, isdir
 from dataclasses import dataclass, field
+import re
 import sys
 from typing import Optional, Dict, Sequence
 import numpy as np
@@ -135,6 +136,10 @@ class TrainingArguments(transformers.Seq2SeqTrainingArguments):
         default=False,
         metadata={"help": "Use 8-bit adam."}
     )
+    lora_modules: str = field(
+        default=None,
+        metadata={"help": "Select layers to add LoRA to. Default or 'all' selects all linear layers except the head, 'attention' selects the attention layers, 'ffn' the feed-forward ones, other values are treated as regex patterns for exact matching layer names."}
+    )
     double_quant: bool = field(
         default=True,
         metadata={"help": "Compress the quantization statistics through double quantization."}
@@ -219,12 +224,17 @@ class GenerationArguments:
     no_repeat_ngram_size: Optional[int] = field(default=0)
 
 def find_all_linear_names(args, model):
+    """Find the model's linear layer names for applying LoRA, and return them in a set. 
+    If args.lora_modules is None or 'all', it selects all linear layers except the head, 'attention' selects the attention layers, 'ffn' the feed-forward ones."""
     cls = bnb.nn.Linear4bit if args.bits == 4 else (bnb.nn.Linear8bitLt if args.bits == 8 else torch.nn.Linear)
     lora_module_names = set()
     for name, module in model.named_modules():
         if isinstance(module, cls):
-            names = name.split('.')
-            lora_module_names.add(names[0] if len(names) == 1 else names[-1])
+            if (args.lora_modules == 'all' or not args.lora_modules
+                or (args.lora_modules == 'attention' and re.search('attn|attention|query|key|value', name.lower()))
+                or (args.lora_modules == 'ffn' and re.search('mlp|ffn', name.lower()))): 
+                names = name.split('.')
+                lora_module_names.add(names[0] if len(names) == 1 else names[-1])
 
 
     if 'lm_head' in lora_module_names: # needed for 16-bit
@@ -320,7 +330,10 @@ def get_accelerate_model(args, checkpoint_dir):
             model = PeftModel.from_pretrained(model, join(checkpoint_dir, 'adapter_model'), is_trainable=True)
         else:
             print(f'adding LoRA modules...')
-            modules = find_all_linear_names(args, model)
+            if not args.lora_modules or args.lora_modules in ['all', 'attention', 'ffn']:
+                modules = find_all_linear_names(args, model)
+            else:
+                modules = args.lora_modules
             config = LoraConfig(
                 r=args.lora_r,
                 lora_alpha=args.lora_alpha,


### PR DESCRIPTION
Implements a feature for specifying the layers of the model that LoRA should be applied to during training. This enables further training memory use reductions, and additional QLoRA training experiments (including but not limited to the reproduction of relevant experiments from the QLoRA paper).

The layer selection is done with the lora_modules str argument. Its value can be: 
- a RegEx pattern for exact matching arbitrary layer names,
- the default value or 'all' selects all linear transformer block layers (i.e. no difference from the last commit)
- 'attention', which selects the attention layers only, 
- 'ffn', which selects the feed-forward ones. 
(The latter 2 aim to reproduce ablation experiments from the paper, but work for e.g. Falcon models too, not just LLaMA.)

While the "lora_modules" argument was already in the guanaco training scripts, it was ignored because only the selection of all linear layers was implemented in this repo. 