### PR TITLE
Add trust_remote_code for AutoTokenizer

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -655,6 +655,7 @@ def train():
         use_fast=False, # Fast tokenizer giving issues.
         tokenizer_type='llama' if 'llama' in args.model_name_or_path else None, # Needed for HF name change
         use_auth_token=args.use_auth_token,
+        trust_remote_code=args.trust_remote_code,
     )
     if tokenizer._pad_token is None:
         smart_tokenizer_and_embedding_resize(


### PR DESCRIPTION
Similar to PR #2,  For models that have customized tokenizers(e.g., [baichuan-inc/baichuan-7B](https://huggingface.co/baichuan-inc/baichuan-7B)), 
we also need to set trust_remote_code=True when initializing the tokenizers. 

Otherwise, it raises an error like this:
```text
ValueError: Tokenizer class xxxTokenizer does not exist or is not currently imported.
```