### PR TITLE
Enhance GPU `bfloat16` support check

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -298,8 +298,7 @@ def get_accelerate_model(args, checkpoint_dir):
         use_auth_token=args.use_auth_token
     )
     if compute_dtype == torch.float16 and args.bits == 4:
-        major, minor = torch.cuda.get_device_capability()
-        if major >= 8:
+        if torch.cuda.is_bf16_supported():
             print('='*80)
             print('Your GPU supports bfloat16, you can accelerate training with the argument --bf16')
             print('='*80)


### PR DESCRIPTION
This PR updates the existing code to check GPU support for bfloat16 using `torch.cuda.is_bf16_supported()` function, which returns a boolean value. This should provide a more robust approach than using `torch.cuda.get_device_capability()`.