### PR TITLE
Set `ddp_find_unused_parameters` to False when using distributed training

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -679,7 +679,10 @@ def train():
     # When using distributed training, the value of the flag find_unused_parameters passed to
     # DistributedDataParallel. Will default to False if gradient checkpointing is used, True otherwise.
     if os.environ.get('LOCAL_RANK') is not None:
-        training_args.ddp_find_unused_parameters = False
+        if training_args.gradient_checkpointing:
+            training_args.ddp_find_unused_parameters = False
+        else:
+            training_args.ddp_find_unused_parameters = True
 
     trainer = Seq2SeqTrainer(
         model=model,

--- a/qlora.py
+++ b/qlora.py
@@ -675,7 +675,12 @@ def train():
     set_seed(args.seed)
 
     data_module = make_data_module(tokenizer=tokenizer, args=args)
-    
+
+    # When using distributed training, the value of the flag find_unused_parameters passed to
+    # DistributedDataParallel. Will default to False if gradient checkpointing is used, True otherwise.
+    if os.environ.get('LOCAL_RANK') is not None:
+        training_args.ddp_find_unused_parameters = False
+
     trainer = Seq2SeqTrainer(
         model=model,
         tokenizer=tokenizer,


### PR DESCRIPTION
As described in [Huggingface doc](https://huggingface.co/transformers/v4.9.0/main_classes/trainer.html#seq2seqtrainingarguments), `ddp_find_unused_parameters` should be set to False if enable gradient_checkpointing.

I've tested on my machine with 2 3090 Ti GPUs, run with following scripts:
```
WORLD_SIZE=2 CUDA_VISIBLE_DEVICES=0,1 torchrun \
--nproc_per_node=2 \
--master_port=1234 \
qlora.py \
    --model_name_or_path meta-llama/Llama-2-7b-hf \
    --use_auth \
``` 

It may resolve the #12 .