### PR TITLE
Update qlora.py

### DIFF
--- a/qlora.py
+++ b/qlora.py
@@ -287,7 +287,7 @@ class SavePeftModelCallback(transformers.TrainerCallback):
         self.save_model(args, state, kwargs)
 
 def get_accelerate_model(args, checkpoint_dir):
-
+    n_gpus = 0
     if torch.cuda.is_available():
         n_gpus = torch.cuda.device_count()
     if is_ipex_available() and torch.xpu.is_available():


### PR DESCRIPTION
add n_gpus = 0 default value to get_accelerate_model

Fixes this error:

Traceback (most recent call last):
  File "qlora.py", line 841, in <module>
    train()
  File "qlora.py", line 704, in train
    model, tokenizer = get_accelerate_model(args, checkpoint_dir)
  File "qlora.py", line 297, in get_accelerate_model
    max_memory = {i: max_memory for i in range(n_gpus)}
UnboundLocalError: local variable 'n_gpus' referenced before assignment
