### PR TITLE
additional load_in_4bit removed

### DIFF
--- a/examples/guanaco_generate.py
+++ b/examples/guanaco_generate.py
@@ -41,7 +41,8 @@ model = AutoModelForCausalLM.from_pretrained(
     model_name_or_path,
     torch_dtype=torch.bfloat16,
     device_map={"": 0},
-    load_in_4bit=True,
+    #load_in_4bit is already set in config, it can't be twice!
+    #load_in_4bit=True,
     quantization_config=BitsAndBytesConfig(
         load_in_4bit=True,
         bnb_4bit_compute_dtype=torch.bfloat16,


### PR DESCRIPTION
In this PR the additional `load_in_4bit=True` is removed because in the `quantization_config` the `load_in_4bit` is already set to `True`, it cannot be duplicated!